### PR TITLE
Implement TryFrom on RpcValue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvproto"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 
 [dependencies]

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2,7 +2,7 @@
 
 /// mantisa: 56, exponent: 8;
 /// I'm storing whole Decimal in one i64 to keep size_of RpcValue == 24
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Decimal (i64);
 
 impl Decimal {


### PR DESCRIPTION
Implements `TryFrom<&RpcValue>` and `TryFrom<RpcValue>` for various
basic types and their references.
    
`TryFrom<&RpcValue>` would be useful e.g. for RPC requests params
parsing, where `RpcMessge::param()` returns `Option<&RpcValue>`.

`TryFrom<RpcValue>` can provide more efficient implementation for
larger datatypes (Blob, List, Map, String), where the returned
value is just moved out of the underlying Box without cloning.
    
Crates using this library can further add any implementations of
`TryFrom<RpcValue>` or `TryFrom<&RpcValue>` for their own types
and  get a uniform way to perform all types conversions from `RpcValue`.