### PR TITLE
Implement `TryFrom<RpcValue>` for container types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvproto"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Provides convenient transformation of a RpcValue of type `List`, `Map` and `IMap` to `Vec<T>`, `BTreeMap<String, T>` and `BTreeMap<i32, T>` respectively for any `T` that also implements `TryFrom<RpcValue>`. Implemented also for `&Rpcvalue`.

Version bumped to 3.0.2