### PR TITLE
Fix TryFromRpcValue conversion from Option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ workspace = { members = ["libshvproto-macros"] }
 
 [package]
 name = "shvproto"
-version = "3.0.12"
+version = "3.0.13"
 edition = "2021"
 
 [dependencies]

--- a/libshvproto-macros/src/lib.rs
+++ b/libshvproto-macros/src/lib.rs
@@ -70,7 +70,10 @@ pub fn derive_from_rpcvalue(item: TokenStream) -> TokenStream {
 
                 if is_option(&field.ty) {
                     struct_initializers.extend(quote!{
-                        #identifier: get_key(#field_name).ok().and_then(|x| x.try_into().ok()),
+                        #identifier: match get_key(#field_name).ok() {
+                            Some(x) => Some(x.try_into()?),
+                            None => None,
+                        },
                     });
                     rpcvalue_inserts.extend(quote!{
                         if let Some(val) = value.#identifier {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -129,6 +129,14 @@ mod test {
         });
     }
 
+    #[test]
+    #[should_panic]
+    fn optional_field_failing() {
+        let _x: OptionalFieldStruct = shvproto::make_map!(
+            "optionalIntField" => "bar"
+        ).try_into().expect("Failed to parse");
+    }
+
     fn test_case<T>(v: T)
     where
         T: TryFrom<shvproto::RpcValue> + Into<shvproto::RpcValue> + std::fmt::Debug + Clone + PartialEq,


### PR DESCRIPTION
If a contained value cannot be converted, conversion error should be returned instead of None.