### PR TITLE
TryFromRpcValue: Add support for enum with named fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ workspace = { members = ["libshvproto-macros"] }
 
 [package]
 name = "shvproto"
-version = "3.0.13"
+version = "3.0.14"
 edition = "2021"
 
 [dependencies]

--- a/libshvproto-macros/src/lib.rs
+++ b/libshvproto-macros/src/lib.rs
@@ -369,7 +369,8 @@ pub fn derive_from_rpcvalue(item: TokenStream) -> TokenStream {
                         .and_then(|val| val
                             .try_into()
                             .map_err(|e: String| "Cannot parse `".to_string() + #tag_key + "` field: " + &e)
-                        )?;
+                        )
+                        .map_err(|e| "Cannot get tag: ".to_string() + &e)?;
 
                     match tag.as_str() {
                         #(#match_arms_tags)*

--- a/src/rpcvalue.rs
+++ b/src/rpcvalue.rs
@@ -700,6 +700,7 @@ macro_rules! try_from_rpc_value {
 }
 
 try_from_rpc_value_ref!(());
+try_from_rpc_value!(());
 try_from_rpc_value_ref!(bool);
 try_from_rpc_value!(bool);
 try_from_rpc_value_ref!(&'a str);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -291,4 +291,54 @@ mod test {
         }.into();
         let _v: EnumWithNamedFields = rv.try_into().unwrap();
     }
+
+    #[derive(Clone,Debug,PartialEq,TryFromRpcValue)]
+    #[rpcvalue(tag = "os")]
+    pub enum EnumWithNamedFieldsCustomTag {
+        Linux { shell: String, user: String, uptime_days: i32, },
+        MacOsX { shell: String, user: String, uptime_days: i32, },
+        Windows { user: Option<String>, number_of_failures: i64 },
+    }
+
+    #[test]
+    fn enum_with_named_fields_custom_tag() {
+        test_case(EnumWithNamedFields::Linux { user: "alice".to_string(), shell: "bash".to_string(), uptime_days: 888 });
+        test_case(EnumWithNamedFields::MacOsX { shell: "zsh".to_string(), user: "bob".to_string(), uptime_days: 666, });
+        test_case(EnumWithNamedFields::Windows { user: Some("boomer".to_string()), number_of_failures: 12 << 33 });
+    }
+
+    #[test]
+    fn enum_with_named_fields_custom_tag_tryinto() {
+        let rv: shvproto::RpcValue = shvproto::make_map!{
+            "os" => "linux",
+            "user" => "alice",
+            "shell" => "bash",
+            "uptimeDays" => 10,
+        }.into();
+        let _v: EnumWithNamedFieldsCustomTag = rv.try_into().unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn enum_with_named_fields_custom_tag_type_mismatch() {
+        let rv: shvproto::RpcValue = shvproto::make_map!{
+            "os" => 0,
+            "user" => "alice",
+            "shell" => "bash",
+            "uptimeDays" => 10,
+        }.into();
+        let _v: EnumWithNamedFieldsCustomTag = rv.try_into().unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn enum_with_named_fields_custom_tag_missing() {
+        let rv: shvproto::RpcValue = shvproto::make_map!{
+            "type" => "linux",
+            "user" => "alice",
+            "shell" => "bash",
+            "uptimeDays" => 10,
+        }.into();
+        let _v: EnumWithNamedFieldsCustomTag = rv.try_into().unwrap();
+    }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -236,4 +236,59 @@ mod test {
         let rv = shvproto::RpcValue::from("foo");
         let _v: UnitVariantsOnlyEnum = rv.try_into().unwrap();
     }
+
+    #[derive(Clone,Debug,PartialEq,TryFromRpcValue)]
+    pub enum EnumWithNamedFields {
+        Linux { shell: String, user: String, uptime_days: i32, },
+        MacOsX { shell: String, user: String, uptime_days: i32, },
+        Windows { user: Option<String>, number_of_failures: i64 },
+    }
+
+    #[test]
+    fn enum_with_named_fields() {
+        test_case(EnumWithNamedFields::Linux { user: "alice".to_string(), shell: "bash".to_string(), uptime_days: 888 });
+        test_case(EnumWithNamedFields::MacOsX { shell: "zsh".to_string(), user: "bob".to_string(), uptime_days: 666, });
+        test_case(EnumWithNamedFields::Windows { user: Some("boomer".to_string()), number_of_failures: 12 << 33 });
+    }
+
+    #[test]
+    #[should_panic]
+    fn enum_with_named_fields_invalid_type_failing() {
+        let rv = shvproto::RpcValue::from("foo");
+        let _v: EnumWithNamedFields = rv.try_into().unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn enum_with_named_fields_missing_tag_failing() {
+        let rv: shvproto::RpcValue = shvproto::make_map!{
+            "user" => "alice",
+            "shell" => "csh",
+            "uptimeDays" => 1,
+        }.into();
+        let _v: EnumWithNamedFields = rv.try_into().unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn enum_with_named_fields_missing_field_failing() {
+        let rv: shvproto::RpcValue = shvproto::make_map!{
+            "type" => "macOsX",
+            "user" => "alice",
+            "uptimeDays" => 1,
+        }.into();
+        let _v: EnumWithNamedFields = rv.try_into().unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn enum_with_named_fields_field_type_mismatch_failing() {
+        let rv: shvproto::RpcValue = shvproto::make_map!{
+            "type" => "macOsX",
+            "user" => "alice",
+            "shell" => vec!["bash", "sh"],
+            "uptimeDays" => 1,
+        }.into();
+        let _v: EnumWithNamedFields = rv.try_into().unwrap();
+    }
 }


### PR DESCRIPTION
Enum variants with named fields are discriminated by internal tag, which defaults to "type" and can be customized by
attribute `#[rpcvalue(tag = "new_value")]` attached to the enum.