### PR TITLE
TryFromRpcValue: Remove stringification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ workspace = { members = ["libshvproto-macros"] }
 
 [package]
 name = "shvproto"
-version = "3.0.17"
+version = "3.0.18"
 edition = "2021"
 
 [dependencies]

--- a/libshvproto-macros/Cargo.toml
+++ b/libshvproto-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libshvproto-macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/libshvproto-macros/src/lib.rs
+++ b/libshvproto-macros/src/lib.rs
@@ -303,9 +303,9 @@ pub fn derive_from_rpcvalue(item: TokenStream) -> TokenStream {
                     syn::Fields::Unit => {
                         let variant_ident_name = variant_ident.to_string().to_case(Case::Camel);
                         match_arms_ser.extend(quote!{
-                            #struct_identifier::#variant_ident => shvproto::RpcValue::from(stringify!(#variant_ident_name)),
+                            #struct_identifier::#variant_ident => shvproto::RpcValue::from(#variant_ident_name),
                         });
-                        add_type_matcher(&mut match_arms_de, quote!{String(s) if s.as_str() == stringify!(#variant_ident_name)}, quote!{#variant_ident}, quote!());
+                        add_type_matcher(&mut match_arms_de, quote!{String(s) if s.as_str() == #variant_ident_name}, quote!{#variant_ident}, quote!());
                     },
                     syn::Fields::Named(variant_fields) => {
                         if let Some((matched_variant_ident, matched_variant_type)) = map_has_been_matched_as_map {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -231,6 +231,13 @@ mod test {
     }
 
     #[test]
+    fn unit_variants_enum_representation() {
+        let x = shvproto::RpcValue::from("variant1");
+        let y: UnitVariantsOnlyEnum = x.clone().try_into().unwrap();
+        assert_eq!(x, y.into());
+    }
+
+    #[test]
     #[should_panic]
     fn unit_variants_enum_failing() {
         let rv = shvproto::RpcValue::from("foo");


### PR DESCRIPTION
variant_ident_name is already a string, so stringify! would add one more pair of double quotes inside the string.