### PR TITLE
Make simple_logger a dependency only for cp2cp

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Build and Install Binary
       run: |
         mkdir -p ${{github.workspace}}/install
-        cargo install --path '${{github.workspace}}' --root '${{github.workspace}}/install' --target ${{ matrix.target }}
+        cargo install --path '${{github.workspace}}' --root '${{github.workspace}}/install' --target ${{ matrix.target }} --features cp2cp
       shell: bash
 
     - name: Upload Artifact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,20 +2,20 @@ workspace = { members = ["libshvproto-macros"] }
 
 [package]
 name = "shvproto"
-version = "3.0.18"
+version = "3.0.19"
 edition = "2021"
 
 [dependencies]
 libshvproto-macros = { path = "./libshvproto-macros" }
-simple_logger = { git = "https://github.com/fvacek/rust-simple_logger.git", branch = "main", features = ["stderr"] }
-
 log = "0.4.21"
 bytes = "1.6.0"
 chrono = "0.4.38"
 hex = "0.4.3"
 clap = { version = "4.5.7", features = ["derive"] }
+simple_logger = { version = "5.0.0", features = ["stderr"], optional = true }
 
 [features]
+cp2cp = ["simple_logger"]
 
 # Enables feature `min_specialization` of nightly compiler and provides
 # special `impl From<Collection<RpcValue>> for RpcValue` to just move
@@ -24,3 +24,4 @@ specialization = []
 
 [[bin]]
 name = "cp2cp"
+required-features = ["cp2cp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.5.7", features = ["derive"] }
 simple_logger = { version = "5.0.0", features = ["stderr"], optional = true }
 
 [features]
-cp2cp = ["simple_logger"]
+cp2cp = ["dep:simple_logger"]
 
 # Enables feature `min_specialization` of nightly compiler and provides
 # special `impl From<Collection<RpcValue>> for RpcValue` to just move

--- a/libshvproto-macros/Cargo.toml
+++ b/libshvproto-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libshvproto-macros"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [lib]
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-convert_case = "0.6.0"
+convert_case = "0.7.0"
 proc-macro2 = "1.0.86"
 quote = "1.0.36"
 syn = "2.0.68"


### PR DESCRIPTION
Libraries should link only to the log crate: https://docs.rs/log/latest/log/#in-libraries