### PR TITLE
Reimplement parse_log_verbosity()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ workspace = { members = ["libshvproto-macros"] }
 
 [package]
 name = "shvproto"
-version = "3.0.19"
+version = "3.1.0"
 edition = "2021"
 
 [dependencies]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,24 +1,30 @@
-use log::{LevelFilter};
+use log::LevelFilter;
 
-pub fn parse_log_verbosity<'a>(verbosity: &'a str, module_path: &'a str) -> Vec<(&'a str, LevelFilter)> {
-    let mut ret: Vec<(&str, LevelFilter)> = Vec::new();
-    for module_level_str in verbosity.split(',') {
-        let module_level: Vec<_> = module_level_str.split('%').collect();
-        // Using `get(0)` looks more consistent along with the following `get(1)`
-        #[allow(clippy::get_first)]
-        let name = *module_level.get(0).unwrap_or(&".");
-        let level = *module_level.get(1).unwrap_or(&"D");
-        let module = if name == "." { module_path } else { name };
-        let level = match level {
-            "E" => LevelFilter::Error,
-            "W" => LevelFilter::Warn,
-            "I" => LevelFilter::Info,
-            "D" => LevelFilter::Debug,
-            _ => LevelFilter::Trace,
-        };
-        ret.push((module, level));
-    }
-    ret
+pub fn parse_log_verbosity<'a>(verbosity: &'a str, module_path: &'a str) -> Vec<(Option<&'a str>, LevelFilter)> {
+    verbosity
+        .split(',')
+        .map(|module_level_str| {
+            let (name, level) = module_level_str
+                .split_once('=')
+                .unwrap_or((module_level_str, "D"));
+            let level = if level == "" { "D" } else { level };
+            let module = if name == "" {
+                None
+            } else if name == "." {
+                Some(module_path)
+            } else {
+                Some(name)
+            };
+            let level = match level {
+                "E" => LevelFilter::Error,
+                "W" => LevelFilter::Warn,
+                "I" => LevelFilter::Info,
+                "D" => LevelFilter::Debug,
+                _ => LevelFilter::Trace,
+            };
+            (module, level)
+        })
+        .collect::<Vec<_>>()
 }
 
 pub fn hex_array(data: &[u8]) -> String {
@@ -69,4 +75,33 @@ pub fn hex_dump(data: &[u8]) -> String {
     ret
 }
 
+#[cfg(test)]
+mod tests {
+    use std::iter::zip;
 
+    use log::LevelFilter;
+
+    use super::parse_log_verbosity;
+
+    #[test]
+    fn log_verbosity() {
+        let current_module = module_path!();
+        let data = vec![
+            ("", vec![(None, LevelFilter::Debug)]),
+            (".", vec![(Some(current_module), LevelFilter::Debug)]),
+            (".=I", vec![(Some(current_module), LevelFilter::Info)]),
+            ("mod", vec![(Some("mod"), LevelFilter::Debug)]),
+            ("foo,bar", vec![(Some("foo"), LevelFilter::Debug), (Some("bar"), LevelFilter::Debug)]),
+            ("foo::bar=I", vec![(Some("foo::bar"), LevelFilter::Info)]),
+            ("=W,foo", vec![(None, LevelFilter::Warn), (Some("foo"), LevelFilter::Debug)]),
+            ("foo=I,bar=E", vec![(Some("foo"), LevelFilter::Info), (Some("bar"), LevelFilter::Error)]),
+        ];
+        for (verbosity, expected_result) in data {
+            let result = parse_log_verbosity(verbosity, current_module);
+            assert_eq!(result.len(), expected_result.len(), "verbosity: `{verbosity}`");
+            for ((module, filter), (module_expected, filter_expected)) in zip(result, expected_result) {
+                assert!(module == module_expected && filter == filter_expected, "verbosity: `{verbosity}`");
+            }
+        }
+    }
+}


### PR DESCRIPTION
The function is refactored to use `split_once()` instead of `split()` and make it possible to specify default log level.