### PR TITLE
Tag nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,6 +85,11 @@ jobs:
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+      - uses: rickstaa/action-create-tag@v1
+        with:
+          tag: "nightly"
+          force_push_tag: true
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
So that our nightly release has the correct source code artifact.