### PR TITLE
serde: Fix datetime human readable parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "shvproto"
 description = "Rust implementation of the SHV protocol"
 license = "MIT"
 repository = "https://github.com/silicon-heaven/libshvproto-rs"
-version = "6.1.4"
+version = "6.1.5"
 edition = "2024"
 
 [dependencies]

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -431,7 +431,11 @@ impl<'de> serde::Deserialize<'de> for crate::DateTime {
             }
         }
 
-        deserializer.deserialize_newtype_struct("DateTime", DateTimeVisitor)
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(DateTimeVisitor)
+        } else {
+            deserializer.deserialize_newtype_struct("DateTime", DateTimeVisitor)
+        }
     }
 }
 


### PR DESCRIPTION
We are serializing as plain strings in this mode, so we also need to deserialize with plain strings. The previous code tried to deserialize from a newtype struct string.