### PR TITLE
Remove specialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "shvproto"
 description = "Rust implementation of the SHV protocol"
 license = "MIT"
 repository = "https://github.com/silicon-heaven/libshvproto-rs"
-version = "7.0.1"
+version = "8.0.0"
 edition = "2024"
 
 [dependencies]
@@ -25,11 +25,6 @@ assert_cmd = "2.0"
 cp2cp = ["dep:clap", "dep:simple_logger"]
 serde = ["dep:serde"]
 cq = ["dep:jaq-all"]
-
-# Enables feature `min_specialization` of nightly compiler and provides
-# special `impl From<Collection<RpcValue>> for RpcValue` to just move
-# the data without iterating through collections.
-specialization = []
 
 [[bin]]
 name = "cp2cp"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "specialization", feature(min_specialization))]
-
 pub mod chainpack;
 pub mod cpon;
 #[cfg(feature = "cq")]

--- a/src/rpcvalue.rs
+++ b/src/rpcvalue.rs
@@ -275,45 +275,37 @@ where
     }
 }
 
-macro_rules! impl_container_conversions {
-    ($($fn_specifier:ident)?) => {
-        impl<T: Into<RpcValue>> From<Vec<T>> for Value {
-            $($fn_specifier)? fn from(value: Vec<T>) -> Self {
-                Value::List(Box::new(
-                        value
-                        .into_iter()
-                        .map(Into::into)
-                        .collect::<Vec<_>>()))
-            }
-        }
-        impl<T: Into<RpcValue>> From<BTreeMap<String, T>> for Value {
-            $($fn_specifier)? fn from(value: BTreeMap<String, T>) -> Self {
-                Value::Map(Box::new(
-                        value
-                        .into_iter()
-                        .map(|(k, v)| (k, v.into()))
-                        .collect::<BTreeMap<_,_>>()
-                ))
-            }
-        }
-        impl<T: Into<RpcValue>> From<BTreeMap<i32, T>> for Value {
-            $($fn_specifier)? fn from(value: BTreeMap<i32, T>) -> Self {
-                Value::IMap(Box::new(
-                        value
-                        .into_iter()
-                        .map(|(k, v)| (k, v.into()))
-                        .collect::<BTreeMap<_,_>>()
-                ))
-            }
-        }
-    };
+impl<T: Into<RpcValue>> From<Vec<T>> for Value {
+    fn from(value: Vec<T>) -> Self {
+        Value::List(Box::new(
+                value
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<_>>()))
+    }
 }
 
-#[cfg(feature = "specialization")]
-impl_container_conversions!(default);
+impl<T: Into<RpcValue>> From<BTreeMap<String, T>> for Value {
+    fn from(value: BTreeMap<String, T>) -> Self {
+        Value::Map(Box::new(
+                value
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect::<BTreeMap<_,_>>()
+        ))
+    }
+}
 
-#[cfg(not(feature = "specialization"))]
-impl_container_conversions!();
+impl<T: Into<RpcValue>> From<BTreeMap<i32, T>> for Value {
+    fn from(value: BTreeMap<i32, T>) -> Self {
+        Value::IMap(Box::new(
+                value
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect::<BTreeMap<_,_>>()
+        ))
+    }
+}
 
 fn format_err_try_from(expected_type: &str, actual_type: &str) -> String {
     format!("Expected type `{expected_type}`, got `{actual_type}`")


### PR DESCRIPTION
I think the specialization was only really useful if you had a Vec<RpcValue> where you could skip the into_iter/collect. Where you could get improved performance - the Vec could just be moved. I don't really think you usually have a Vec<RpcValue> anyway, and even if you did, this extra code is not worth maintaining for the extra performance.